### PR TITLE
Flow solve update

### DIFF
--- a/include/flow/FlowSolver.hpp
+++ b/include/flow/FlowSolver.hpp
@@ -1016,7 +1016,7 @@ namespace minicombust::flow
 			void limit_phi_gradient(T *phi_component, vec<T> *phi_grad_component);
 			void get_phi_gradient ( T *phi_component, vec<T> *phi_grad_component, bool pressure );
 
-			void Scalar_solve(int type, T *phi_component, vec<T> *phi_grad_component, T *old_phi);
+			void Scalar_solve(int type, T *phi_component, vec<T> *phi_grad_component);
 			void FluxScalar(int type, T *phi_component, vec<T> *phi_grad_component);
 			void solveTurbulenceModels(int type);
 

--- a/include/flow/FlowSolver.inl
+++ b/include/flow/FlowSolver.inl
@@ -2758,7 +2758,7 @@ namespace minicombust::flow
 		}
 	}
 
-	template<typename T> void FlowSolver<T>::Scalar_solve(int type, T *phi_component, vec<T> *phi_grad_component, T *old_phi)
+	template<typename T> void FlowSolver<T>::Scalar_solve(int type, T *phi_component, vec<T> *phi_grad_component)
 	{
 		/*Solve for a general scalar used for most transport equations
           Follows the general procedure:
@@ -3098,23 +3098,23 @@ namespace minicombust::flow
         calculate_pressure();
 		
 		//Turbulence solve
-		Scalar_solve(TERBTE, phi.TE, phi_grad.TE, phi.TE);
-		Scalar_solve(TERBED, phi.ED, phi_grad.ED, phi.ED);
+		Scalar_solve(TERBTE, phi.TE, phi_grad.TE);
+		Scalar_solve(TERBED, phi.ED, phi_grad.ED);
 		
 		//temperature solve
-		Scalar_solve(TEMP, phi.TEM, phi_grad.TEM, phi.TEM);
+		Scalar_solve(TEMP, phi.TEM, phi_grad.TEM);
 
 		//fuel mixture fraction solve
-		Scalar_solve(FUEL, phi.FUL, phi_grad.FUL, phi.FUL);
+		Scalar_solve(FUEL, phi.FUL, phi_grad.FUL);
 
 		//rection progression solve
-		Scalar_solve(PROG, phi.PRO, phi_grad.PRO, phi.PRO);
+		Scalar_solve(PROG, phi.PRO, phi_grad.PRO);
 	
 		//Solve Variance of mixture fraction as transport equ
-		Scalar_solve(VARFU, phi.VARF, phi_grad.VARF, phi.VARF);
+		Scalar_solve(VARFU, phi.VARF, phi_grad.VARF);
 
 		//Solve Variance of progression as trasnport equ
-		Scalar_solve(VARPR, phi.VARP, phi_grad.VARP, phi.VARP);
+		Scalar_solve(VARPR, phi.VARP, phi_grad.VARP);
 
 		fgm_lookup_time -= MPI_Wtime();
 		//Look up results from the FGM look-up table

--- a/include/flow/FlowSolver.inl
+++ b/include/flow/FlowSolver.inl
@@ -2120,7 +2120,6 @@ namespace minicombust::flow
 
 		VecZeroEntries(b);
 		VecZeroEntries(u);
-		PetscReal norm;
 		int flag = 1;
 		//NOTE: We do this since the solution falls apart with RHS vector close to zero.
 		//TODO: Compare zero with RHS using confidence if that is acceptable use that.
@@ -2140,8 +2139,6 @@ namespace minicombust::flow
 				VecSetValue(b, i+mesh->local_cells_disp, 0.0, INSERT_VALUES);
 			}
 		}
-		
-		VecNorm(b, NORM_2, &norm);	
 		
 		VecAssemblyBegin(b);
         VecAssemblyEnd(b);
@@ -3122,7 +3119,7 @@ namespace minicombust::flow
 		fgm_lookup_time += MPI_Wtime();
 		compute_time += MPI_Wtime();
 
-		if(((timestep_count + 1) % 5) == 0)
+		/*if(((timestep_count + 1) % 5) == 0)
 		{
 			if(mpi_config->particle_flow_rank == 0)
 			{
@@ -3141,7 +3138,7 @@ namespace minicombust::flow
 				}
 				MPI_Barrier(mpi_config->particle_flow_world);
 			}
-		}
+		}*/
 
 		if(((timestep_count + 1) % TIMER_OUTPUT_INTERVAL == 0) && FLOW_SOLVER_TIME)
         {

--- a/include/geometry/Mesh.hpp
+++ b/include/geometry/Mesh.hpp
@@ -245,6 +245,7 @@ namespace minicombust::geometry
                     MPI_Reduce(MPI_IN_PLACE, &total_flow_term_size,                  1, MPI_UINT64_T, MPI_SUM, 0, mpi_config->world);
                     MPI_Reduce(MPI_IN_PLACE, &total_particle_term_size,              1, MPI_UINT64_T, MPI_SUM, 0, mpi_config->world);
 
+					//TODO: faces_size here is zero since it is a particle cell					
                     if (mpi_config->solver_type == PARTICLE)
                         MPI_Reduce(MPI_IN_PLACE, &particle_memory_usage, 1, MPI_UINT64_T, MPI_SUM, 0, mpi_config->particle_flow_world);
 

--- a/src/minicombust.cpp
+++ b/src/minicombust.cpp
@@ -50,17 +50,17 @@ int main (int argc, char ** argv)
     MPI_Op_create(&sum_particle_aos<double>, 1, &mpi_config.MPI_PARTICLE_OPERATION);
 
     // Run Configuration
-    const uint64_t ntimesteps                   = (argc > 5) ? atoi(argv[5]) : 1500; //5 1500;
-    const double   delta                        = 1.0e-3; //-8
+    const uint64_t ntimesteps                   = (argc > 5) ? atoi(argv[5]) : 1500;
+    const double   delta                        = 1.0e-8;
     const int64_t output_iteration              = (argc > 4) ? atoi(argv[4]) : 10;
     const uint64_t particles_per_timestep       = (argc > 2) ? atoi(argv[2]) : 10;
    
 
     // Mesh Configuration
     const uint64_t modifier                = (argc > 3) ? atoi(argv[3]) : 10;
-    vec<double>    box_dim                 = {0.5, 0.5, 0.5};
-    vec<uint64_t>  elements_per_dim        = {modifier*1,   modifier*1,  modifier*1};
-												//*2
+    vec<double>    box_dim                 = {0.1, 0.5, 0.5};
+    vec<uint64_t>  elements_per_dim        = {modifier*2,   modifier*1,  modifier*1};
+
     if (mpi_config.rank == 0)  
     {
         printf("Starting miniCOMBUST..\n");


### PR DESCRIPTION
Quick Fix for multiple flow ranks bug.

--Returned the initial conditions to the original numbers.
--commented printing at each fifth timestep (this probably shouldn't have been committed anyway). 