### PR TITLE
cpx intergration on GPUs

### DIFF
--- a/include/cpx/cpx_utils.inl
+++ b/include/cpx/cpx_utils.inl
@@ -1,0 +1,139 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <mpi.h>
+#include <chrono>
+#include <algorithm>
+#include "src_op/const_op.h"
+#include "src/structures.h"
+#include "src_op/coupler_config.h"
+
+void read_inputs(int *particle_ranks, uint64_t *particles_per_timestep, uint64_t *modifier, int64_t *output_iteration){
+	FILE *inputs = fopen("combust.input", "r");
+	int buff_len = 1024;
+	char line_buff[buff_len];
+	
+	if(inputs == NULL){
+		fprintf(stderr, "Can't open input file combust.input\n");
+        exit(1);
+    }
+	while(fgets(line_buff, buff_len, inputs)){
+		char* token = strtok(line_buff, " ");
+		if(strcmp(token, "particle_ranks") == 0){
+			*particle_ranks = stoi(strtok(NULL, " "));
+		}else if(strcmp(token, "ppt") == 0){
+            *particles_per_timestep = stoull(strtok(NULL, " "));
+		}else if(strcmp(token, "mesh_size") == 0){
+            *modifier = stoull(strtok(NULL, " "));
+		}else if(strcmp(token, "output") == 0){
+            *output_iteration = stoull(strtok(NULL, " "));
+		}
+	}
+}
+
+int find_unit(struct unit units[], struct locators relative_positions[],
+				   int world_rank, char type){
+	int our_unit_num = relative_positions[world_rank].placelocator;
+    int unit_count = 0;
+    int work_count = 1; //since units start from 1
+    bool found = false;
+	if( type == 'C'){
+		while(!found){
+            if(units[unit_count].type == 'C' && our_unit_num == work_count){
+                found=true;
+            }else{
+                if(units[unit_count].type == 'C'){
+                    work_count++;
+                }
+                unit_count++;
+            }
+        }
+		return unit_count;
+	}else{
+		while(!found){
+			if(units[unit_count].type == type && our_unit_num == work_count){
+				found=true;
+			}else{
+				if(units[unit_count].type != 'C'){
+					 work_count++;
+				}
+				unit_count++;
+			}
+		}
+		return unit_count;
+	}
+}
+
+void send_num_data(struct unit units[], struct locators relative_positions[],
+				   long long grid_size, double **p_variables_data,
+				   double **p_variables_recv){
+	
+	int world_rank;
+	MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+	int unit_count = find_unit(units, relative_positions, world_rank, 'S');
+	int total_coupler_unit_count = units[unit_count].coupler_ranks.size();
+    int ranks_per_coupler;
+	double nodes_size;
+	//TODO: work out what size the exchange should be
+	int buff_size = std::round(0.05 * (double) grid_size/8 * NVAR);
+	*p_variables_data = (double*) malloc(buff_size * sizeof(double));
+	*p_variables_recv = (double*) malloc(buff_size * sizeof(double));
+	for(int i = 0; i < buff_size; i++){
+		(*p_variables_data)[i] = std::rand()/1000;
+		(*p_variables_recv)[i] = std::rand()/1000;
+	}
+    for(int z = 0; z < total_coupler_unit_count; z++){
+		ranks_per_coupler = units[unit_count].coupler_ranks[z].size();
+		int coupler_rank = units[unit_count].coupler_ranks[z][0];
+		int unit_count_2 = find_unit(units, relative_positions, coupler_rank, 'C');
+		if(units[unit_count_2].coupling_type == 'C'){
+			nodes_size = std::round(0.018 * (double) grid_size/8);
+		}else if(units[unit_count_2].coupling_type == 'O'){
+			nodes_size = std::round(0.05 * (double) grid_size/8);
+		}
+		for(int z2 = 0; z2 < ranks_per_coupler; z2++){
+			//Send the node sizes to each of the coupler ranks of each coupler unit.
+			MPI_Send(&nodes_size, 1, MPI_DOUBLE, units[unit_count].coupler_ranks[z][z2], 0, MPI_COMM_WORLD);
+		}
+    }
+}
+
+void send_recv_data(struct unit units[], struct locators relative_positions[], 
+					long long grid_size, int cycle_num, int total_cycles, 
+					double *p_variables_data, double *p_variables_recv, FILE *fp){
+	int world_rank;
+	MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+	int unit_count = find_unit(units, relative_positions, world_rank, 'S');
+	int total_coupler_unit_count = units[unit_count].coupler_ranks.size();
+    fprintf(fp, "Mini-Combust cycle %d of %d comms starting\n", (cycle_num/combust_conversion_factor)+1, 
+				total_cycles);
+    for(int j = 0; j < total_coupler_unit_count; j++){
+		//find the coupler unit index
+		int coupler_rank = units[unit_count].coupler_ranks[j][0];
+        int unit_count_2 = find_unit(units, relative_positions, coupler_rank, 'C');
+		double send_size;
+		//work out the amount of data to send
+		if(units[unit_count_2].coupling_type == 'C'){
+            send_size = std::round(0.018 * (double) grid_size/8);
+        }else if(units[unit_count_2].coupling_type == 'O'){
+			send_size = std::round(0.05 * (double) grid_size/8);
+        }
+		//send all the data to the couplers
+        if(hide_search == true && combust_conversion_factor != 1){
+			if((cycle_num % (search_freq*combust_conversion_factor)) == 0){
+				MPI_Send(p_variables_data, send_size, MPI_DOUBLE, coupler_rank, 0, MPI_COMM_WORLD);
+			}else if((cycle_num % combust_conversion_factor) == combust_conversion_factor - 1){
+				MPI_Recv(p_variables_recv, send_size, MPI_DOUBLE, coupler_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+			}else{
+				MPI_Send(p_variables_data, send_size, MPI_DOUBLE, coupler_rank, 0, MPI_COMM_WORLD);
+				MPI_Recv(p_variables_recv, send_size, MPI_DOUBLE, coupler_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+			}
+		}else{
+			MPI_Send(p_variables_data, send_size, MPI_DOUBLE, coupler_rank, 0, MPI_COMM_WORLD);
+			MPI_Recv(p_variables_recv, send_size, MPI_DOUBLE, coupler_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        }
+    }
+	fprintf(fp, "Mini-Combust cycle %d of %d comms ending\n", (cycle_num/combust_conversion_factor)+1, 
+				total_cycles);
+}

--- a/include/examples/mesh_examples.hpp
+++ b/include/examples/mesh_examples.hpp
@@ -8,4 +8,4 @@ using namespace minicombust::geometry;
 
 Mesh<double> *load_boundary_box_mesh(double box_size);
 
-Mesh<double> *load_mesh(MPI_Config *mpi_config, vec<double> mesh_dim, vec<uint64_t> elements_per_dim, int flow_ranks);
+Mesh<double> *load_mesh(MPI_Config *mpi_config, vec<double> mesh_dim, vec<uint64_t> elements_per_dim, int flow_ranks, FILE* fp);

--- a/include/flow/gpu/MemoryTracker.hpp
+++ b/include/flow/gpu/MemoryTracker.hpp
@@ -124,13 +124,13 @@ namespace minicombust::flow
                 }
             }
 
-            void print_usage()
+            void print_usage(FILE *fp)
             {
                 size_t local_size = 0;
                 size_t global_size = 0;
 
                 if (mpi_config->particle_flow_rank == 0)
-                    printf("Flow Host Memory Usage:\n");
+                    fprintf(fp, "Flow Host Memory Usage:\n");
 
                 for (void *ptr : host_vector)
                 {
@@ -139,20 +139,20 @@ namespace minicombust::flow
                     size_t world_size;
                     MPI_Allreduce(&val_pair.second, &world_size, 1, MPI_UINT64_T, MPI_SUM, mpi_config->particle_flow_world);
                     if (mpi_config->particle_flow_rank == 0)
-                        printf("\t%40s        (TOTAL %8.2f GB) (AVG %8.2f GB) \n", val_pair.first.c_str(), (float) world_size / 1.e9, (float) world_size / (1.e9 * (float)mpi_config->particle_flow_world_size));
+                        fprintf(fp, "\t%40s        (TOTAL %8.2f GB) (AVG %8.2f GB) \n", val_pair.first.c_str(), (float) world_size / 1.e9, (float) world_size / (1.e9 * (float)mpi_config->particle_flow_world_size));
                     
                     local_size  += val_pair.second;
                     global_size += world_size;
                 }
                 if (mpi_config->particle_flow_rank == 0)
-                    printf("\t%40s        (TOTAL %8.2f GB) (AVG %8.2f GB) \n", "FLOW TOTAL HOST USAGE", (float) global_size / 1.e9, (float) global_size / (1.e9 * (float)mpi_config->particle_flow_world_size)  );
+                    fprintf(fp, "\t%40s        (TOTAL %8.2f GB) (AVG %8.2f GB) \n", "FLOW TOTAL HOST USAGE", (float) global_size / 1.e9, (float) global_size / (1.e9 * (float)mpi_config->particle_flow_world_size)  );
             
 
                 local_size = 0;
                 global_size = 0;
 
                 if (mpi_config->particle_flow_rank == 0)
-                    printf("Flow Device Memory Usage:\n");
+                    fprintf(fp, "Flow Device Memory Usage:\n");
 
                 for (void *ptr : device_vector)
                 {
@@ -161,13 +161,13 @@ namespace minicombust::flow
                     size_t world_size;
                     MPI_Allreduce(&val_pair.second, &world_size, 1, MPI_UINT64_T, MPI_SUM, mpi_config->particle_flow_world);
                     if (mpi_config->particle_flow_rank == 0)
-                        printf("\t%40s (TOTAL %8.2f GB) (AVG %8.2f GB) \n", val_pair.first.c_str(), (float) world_size / 1.e9, (float) world_size / (1.e9 * (float)mpi_config->particle_flow_world_size));
+                        fprintf(fp, "\t%40s (TOTAL %8.2f GB) (AVG %8.2f GB) \n", val_pair.first.c_str(), (float) world_size / 1.e9, (float) world_size / (1.e9 * (float)mpi_config->particle_flow_world_size));
                     
                     local_size  += val_pair.second;
                     global_size += world_size;
                 }
                 if (mpi_config->particle_flow_rank == 0)
-                    printf("\t%40s (TOTAL %8.2f GB) (AVG %8.2f GB) \n\n", "FLOW TOTAL DEVICE USAGE",  (float) global_size / 1.e9, (float) global_size / (1.e9 * (float)mpi_config->particle_flow_world_size)  );
+                    fprintf(fp, "\t%40s (TOTAL %8.2f GB) (AVG %8.2f GB) \n\n", "FLOW TOTAL DEVICE USAGE",  (float) global_size / 1.e9, (float) global_size / (1.e9 * (float)mpi_config->particle_flow_world_size)  );
             
             
             }

--- a/include/particles/ParticleSolver.inl
+++ b/include/particles/ParticleSolver.inl
@@ -67,40 +67,35 @@ namespace minicombust::particles
 
         MPI_Barrier(mpi_config->world);
 
-        if (mpi_config->rank == 0)
+        if (mpi_config->particle_flow_rank == 0 && output_file == stdout)
         {
-            cout << "Particle Solver Stats:                         " << endl;
-            cout << "\tParticles:                                   " << ((double)logger.num_particles)                                                                   << endl;
-            cout << "\tParticles (per iter):                        " << particle_dist->even_particles_per_timestep*mpi_config->particle_flow_world_size                  << endl;
-            cout << "\tEmitted Particles:                           " << logger.emitted_particles                                                                         << endl;
-            cout << "\tAvg Particles (per iter):                    " << logger.avg_particles                                                                             << endl;
-            cout << endl;
-            cout << "\tCell checks:                                 " << ((double)logger.cell_checks)                                                                     << endl;
-            cout << "\tCell checks (per iter):                      " << ((double)logger.cell_checks) / timesteps                                                         << endl;
-            cout << "\tCell checks (per particle, per iter):        " << ((double)logger.cell_checks) / (((double)logger.num_particles)*timesteps)                        << endl;
-            cout << endl;
-            cout << "\tEdge adjustments:                            " << ((double)logger.position_adjustments)                                                            << endl;
-            cout << "\tEdge adjustments (per iter):                 " << ((double)logger.position_adjustments) / timesteps                                                << endl;
-            cout << "\tEdge adjustments (per particle, per iter):   " << ((double)logger.position_adjustments) / (((double)logger.num_particles)*timesteps)               << endl;
-            cout << "\tLost Particles:                              " << ((double)logger.lost_particles      )                                                            << endl;
-            cout << endl;
-            cout << "\tBoundary Intersections:                      " << ((double)logger.boundary_intersections)                                                          << endl;
-            cout << "\tDecayed Particles:                           " << ((double)logger.decayed_particles)                                                               << endl;
-            cout << "\tDecayed Particles:                           " << round(10000.*(((double)logger.decayed_particles) / ((double)logger.num_particles)))/100. << "% " << endl;
-            cout << "\tBurnt Particles:                             " << ((double)logger.burnt_particles)                                                                 << endl;
-            cout << "\tBreakups:                                    " << ((double)logger.breakups)                                                                        << endl;
-            cout << "\tBreakup Age:                                 " << ((double)logger.breakup_age)                                                                     << endl;
-            cout << endl; 
-            cout << "\tAvg Sent Cells       (avg per rank, block):  " << round(logger.sent_cells_per_block / timesteps)                                                   << endl;
-            cout << "\tTotal Sent Cells     (avg per rank):         " << round(logger.sent_cells / timesteps)                                                             << endl;
-            cout << "\tTotal Recieved Nodes (avg per rank):         " << round(logger.nodes_recieved / timesteps)                                                         << endl;
-            cout << "\tUseful Nodes         (avg per rank):         " << round(logger.useful_nodes_proportion / timesteps)                                                << endl;
-            cout << "\tUseful Nodes (%)     (avg per rank):         " << round(10000.*((logger.useful_nodes_proportion) / (logger.nodes_recieved))) / 100. << "% "        << endl;
-
-            //cout << endl;
-
-            //cout <<"NOTE: REDUCING RELATIVE GAS VEL by 50\% in Particle.hpp while flow isn't implemented!!!" << endl;
-            //cout << endl;
+            fprintf(output_file, "Particle Solver Stats:                         \n");
+            fprintf(output_file, "\tParticles:                                   %e\n", ((double)logger.num_particles));
+            fprintf(output_file, "\tParticles (per iter):                        %lu\n", particle_dist->even_particles_per_timestep*mpi_config->particle_flow_world_size);
+            fprintf(output_file, "\tEmitted Particles:                           %lu\n", logger.emitted_particles);
+            fprintf(output_file, "\tAvg Particles (per iter):                    %e\n", logger.avg_particles);
+            fprintf(output_file, "\n");
+            fprintf(output_file, "\tCell checks:                                 %e\n", ((double)logger.cell_checks));
+            fprintf(output_file, "\tCell checks (per iter):                      %e\n", ((double)logger.cell_checks) / timesteps);
+            fprintf(output_file, "\tCell checks (per particle, per iter):        %.2f\n", ((double)logger.cell_checks) / (((double)logger.num_particles)*timesteps));
+            fprintf(output_file, "\n");
+            fprintf(output_file, "\tEdge adjustments:                            %.2f\n", ((double)logger.position_adjustments));
+            fprintf(output_file, "\tEdge adjustments (per iter):                 %.2f\n", ((double)logger.position_adjustments) / timesteps);
+            fprintf(output_file, "\tEdge adjustments (per particle, per iter):   %.2f\n", ((double)logger.position_adjustments) / (((double)logger.num_particles)*timesteps));
+            fprintf(output_file, "\tLost Particles:                              %.2f\n", ((double)logger.lost_particles      ));
+            fprintf(output_file, "\n");
+            fprintf(output_file, "\tBoundary Intersections:                      %.2f\n", ((double)logger.boundary_intersections));
+            fprintf(output_file, "\tDecayed Particles:                           %e\n", ((double)logger.decayed_particles));
+            fprintf(output_file, "\tDecayed Particles:                           %.2f%%\n", round(10000.*(((double)logger.decayed_particles) / ((double)logger.num_particles)))/100.);
+            fprintf(output_file, "\tBurnt Particles:                             %e\n", ((double)logger.burnt_particles));
+            fprintf(output_file, "\tBreakups:                                    %.2f\n", ((double)logger.breakups));
+            fprintf(output_file, "\tBreakup Age:                                 %.2f\n", ((double)logger.breakup_age));
+            fprintf(output_file, "\n");
+            fprintf(output_file, "\tAvg Sent Cells       (avg per rank, block):  %.0f\n", round(logger.sent_cells_per_block / timesteps));
+            fprintf(output_file, "\tTotal Sent Cells     (avg per rank):         %.0f\n", round(logger.sent_cells / timesteps));
+            fprintf(output_file, "\tTotal Recieved Nodes (avg per rank):         %.0f\n", round(logger.nodes_recieved / timesteps));
+            fprintf(output_file, "\tUseful Nodes         (avg per rank):         %.0f\n", round(logger.useful_nodes_proportion / timesteps));
+            fprintf(output_file, "\tUseful Nodes (%%)     (avg per rank):         %.2f%%\n", round(10000.*((logger.useful_nodes_proportion) / (logger.nodes_recieved))) / 100.);
         }
 
         performance_logger.print_counters(mpi_config->rank, mpi_config->world_size, runtime);
@@ -149,8 +144,8 @@ namespace minicombust::particles
         logger.sent_cells_per_block += avg_sent_cells;
 
 
-        if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Running fn: update_flow_field.\n", mpi_config->rank);
-        if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Sending index sizes.\n", mpi_config->rank);
+        if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Running fn: update_flow_field.\n", mpi_config->rank);
+        if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Sending index sizes.\n", mpi_config->rank);
 
 		// MPI_Barrier(mpi_config->world);
 
@@ -161,9 +156,9 @@ namespace minicombust::particles
             neighbours_size[b] = cell_particle_field_map[b].size();
             if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )
 			{  
-				printf("\tRank %d: Sending %d indexes to block %lu.\n", mpi_config->rank, neighbours_size[b], b);
+				fprintf(output_file, "\tRank %d: Sending %d indexes to block %lu.\n", mpi_config->rank, neighbours_size[b], b);
 			}
-            MPI_Issend(cell_particle_indexes[b], neighbours_size[b], MPI_UINT64_T,                        mpi_config->particle_flow_world_size + b, 0, mpi_config->world, &send_requests[count++  + 0*active_blocks.size()] );
+            MPI_Issend(cell_particle_indexes[b], neighbours_size[b], MPI_UINT64_T,                        b, 0, mpi_config->world, &send_requests[count++  + 0*active_blocks.size()] );
 	
             // MPI_Isend(cell_particle_aos[b],     neighbours_size[b], mpi_config->MPI_PARTICLE_STRUCTURE,  mpi_config->particle_flow_world_size + b, 2, mpi_config->world, &send_requests[count++ + 1*active_blocks.size()] );
         }
@@ -176,23 +171,23 @@ namespace minicombust::particles
             neighbours_size[b] = cell_particle_field_map[b].size();
             if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )
 			{  
-				printf("\tRank %d: Sending %d indexes to block %lu.\n", mpi_config->rank, neighbours_size[b], b);
+				fprintf(output_file, "\tRank %d: Sending %d indexes to block %lu.\n", mpi_config->rank, neighbours_size[b], b);
 			}
 	
             // MPI_Issend(cell_particle_indexes[b], neighbours_size[b], MPI_UINT64_T,                        mpi_config->particle_flow_world_size + b, 0, mpi_config->world, &send_requests[count  + 0*active_blocks.size()] );
-            MPI_Isend(cell_particle_aos[b],     neighbours_size[b], mpi_config->MPI_PARTICLE_STRUCTURE,  mpi_config->particle_flow_world_size + b, 2, mpi_config->world, &send_requests[count++ + 1*active_blocks.size()] );
+            MPI_Isend(cell_particle_aos[b],     neighbours_size[b], mpi_config->MPI_PARTICLE_STRUCTURE,  b, 2, mpi_config->world, &send_requests[count++ + 1*active_blocks.size()] );
         }
 
 
         // MPI_Waitall(active_blocks.size(), send_requests.data(), MPI_STATUSES_IGNORE);
 
-        if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Wait has returned successfully\n", mpi_config->rank);
+        if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Wait has returned successfully\n", mpi_config->rank);
         MPI_Barrier(mpi_config->particle_flow_world);
 
         int sends_done = 1;
-        if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: All index sizes sent.\n", mpi_config->rank);
+        if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: All index sizes sent.\n", mpi_config->rank);
         
-        MPI_Ibcast(&sends_done, 1, MPI_INT, 0, mpi_config->world, &bcast_request);
+        MPI_Ibcast(&sends_done, 1, MPI_INT, (mpi_config->world_size - mpi_config->particle_flow_world_size), mpi_config->world, &bcast_request);
 
         for (uint64_t b : active_blocks)
             cell_particle_field_map[b].clear();
@@ -221,7 +216,7 @@ namespace minicombust::particles
             if ( message_waiting && (posted_recvs < active_blocks.size()) )
             {
                 const uint64_t send_rank = statuses[posted_recvs].MPI_SOURCE;
-                const uint64_t block_id  = statuses[posted_recvs].MPI_SOURCE - mpi_config->particle_flow_world_size;
+                const uint64_t block_id  = statuses[posted_recvs].MPI_SOURCE;
 
                 MPI_Get_count( &statuses[posted_recvs], MPI_UINT64_T, &neighbours_size[block_id] );
                 resize_nodes_arrays(neighbours_size[block_id] + 1, block_id);
@@ -230,7 +225,7 @@ namespace minicombust::particles
                 int active_block_index = find(active_blocks.begin(), active_blocks.end(), block_id) - active_blocks.begin(); 
 
                 // if (mpi_config->rank == 0) printf( "Recving %d node values from %lu. Particles size %lu\n", neighbours_size[block_id], send_rank, particles.size() );
-                if ( PARTICLE_SOLVER_DEBUG )  printf("\tRank %d: Posted %d recieves (ptr %p) for flow block %lu (slots %d %ld max %ld) .\n", mpi_config->rank, neighbours_size[block_id], all_interp_node_indexes[block_id], block_id, active_block_index, active_block_index + active_blocks.size(), recv_requests.size() );
+                if ( PARTICLE_SOLVER_DEBUG )  fprintf(output_file, "\tRank %d: Posted %d recieves (ptr %p) for flow block %lu (slots %d %ld max %ld) .\n", mpi_config->rank, neighbours_size[block_id], all_interp_node_indexes[block_id], block_id, active_block_index, active_block_index + active_blocks.size(), recv_requests.size() );
                 MPI_Irecv ( all_interp_node_indexes[block_id],     neighbours_size[block_id], MPI_UINT64_T,                   send_rank, 0, mpi_config->world, &recv_requests[active_block_index] );
                 MPI_Irecv ( all_interp_node_flow_fields[block_id], neighbours_size[block_id], mpi_config->MPI_FLOW_STRUCTURE, send_rank, 1, mpi_config->world, &recv_requests[active_block_index + active_blocks.size()] );
 
@@ -246,39 +241,11 @@ namespace minicombust::particles
 
             if ( recieve_done && recieve_fld_done && !processed_block[ba] && posted_block_recvs[ba] )
             {
-                // uint64_t size_before = node_to_field_address_map.size();
-
-                // if ( PARTICLE_SOLVER_DEBUG )  
-                // {
-                //     printf("\tRank %d: Indexes (%p ptr) load finished for flow block %lu (slots %lu ) .\n", mpi_config->rank, all_interp_node_indexes[bi], bi, ba );
-
-                //     if      ( (uint64_t) neighbours_size[bi]  >= (node_flow_array_sizes[bi]   / sizeof(flow_aos<T>)) )
-                //         {printf("ERROR RECV VALS : Rank %d Block %lu will write indexes to unallocated memory required size %d max %lu\n", mpi_config->rank, bi, neighbours_size[bi], node_flow_array_sizes[bi] / sizeof(flow_aos<T>)); exit(1);}
-                //     else if ( (uint64_t) neighbours_size[bi]  >= (node_index_array_sizes[bi]  / sizeof(uint64_t)) )
-                //         {printf("ERROR RECV VALS : Rank %d Block %lu will write fields  to unallocated memory required size %d max %lu\n", mpi_config->rank, bi, neighbours_size[bi], node_index_array_sizes[bi] / sizeof(uint64_t)); exit(1);}
-                // }
-
                 #pragma ivdep
                 for (int i = 0; i < neighbours_size[bi]; i++)
                 {
                     node_to_field_address_map[all_interp_node_indexes[bi][i]] = &all_interp_node_flow_fields[bi][i];
-                    
-                    
-                    // if (all_interp_node_indexes[bi][i] > mesh->points_size )
-					// {	
-					// 	printf("ERROR RECV VALS : Rank %d Flow block %lu Value %lu out of range at %d\n", 
-					// 			mpi_config->rank, bi, all_interp_node_indexes[bi][i], i); 
-					// 	exit(1);
-					// })
                 }
-
-				/*if (PARTICLE_SOLVER_DEBUG && size_before != node_to_field_address_map.size())
-                {
-					printf("\tRank %d: Recieving wrong amount of data(+%lu). Block %lu Node map size %ld sent size %d.\n", 
-							mpi_config->rank, node_to_field_address_map.size() - size_before, bi, 
-							node_to_field_address_map.size(), neighbours_size[bi] ); 
-					exit(1);
-				}*/
                     
                 processed_block[ba] = true;
             }
@@ -297,7 +264,7 @@ namespace minicombust::particles
         // MPI_Barrier(mpi_config->world);
         if ( PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )
 		{
-			printf("\tRank %d: Completed comms.\n", mpi_config->rank);
+			fprintf(output_file, "\tRank %d: Completed comms.\n", mpi_config->rank);
         }
 
         performance_logger.my_papi_stop(performance_logger.update_flow_field_event_counts, &performance_logger.update_flow_field_time);
@@ -311,7 +278,7 @@ namespace minicombust::particles
         // TODO: Reuse decaying particle space
         if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  
 		{
-			printf("\tRank %d: Running fn: particle_release.\n", mpi_config->rank);
+			fprintf(output_file, "\tRank %d: Running fn: particle_release.\n", mpi_config->rank);
         }
 		function<void(uint64_t *, uint64_t ***, particle_aos<T> ***)> resize_cell_particles_fn = [this] (uint64_t *elements, uint64_t ***indexes, particle_aos<T> ***cell_particle_fields) { return resize_cell_particle(elements, indexes, cell_particle_fields); };
 
@@ -324,7 +291,7 @@ namespace minicombust::particles
     template<class T> 
     void ParticleSolver<T>::solve_spray_equations()
     {
-        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Running fn: solve_spray_equations.\n", mpi_config->rank);
+        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Running fn: solve_spray_equations.\n", mpi_config->rank);
 
         const uint64_t cell_size       = mesh->cell_size; 
         const uint64_t particles_size  = particles.size(); 
@@ -347,31 +314,17 @@ namespace minicombust::particles
             for (uint64_t n = 0; n < cell_size; n++)
             {
                 if (PARTICLE_SOLVER_DEBUG && (particles[p].cell >= mesh->mesh_size))
-                    {printf("ERROR::: RANK %d Cell %lu out of range\n", mpi_config->rank, particles[p].cell); exit(1);}
+                    {fprintf(output_file, "ERROR::: RANK %d Cell %lu out of range\n", mpi_config->rank, particles[p].cell); exit(1);}
 
                 
                 
                 uint64_t node = mesh->cells[(particles[p].cell - mesh->shmem_cell_disp) * cell_size + n];
                 const uint64_t block_id = mesh->get_block_id(particles[p].cell);
 
-                // if (!PARTICLE_SOLVER_DEBUG && node_to_field_address_map.count(node))
-                // {
-                //     printf("ERROR: PARTICLE RANK %lu DOESN'T HAVE NODE %lu for cell %lu\n", mpi_config->particle_flow_rank, node, particles[p].cell);
-                //     exit(1);
-                // }
-
-                // if (node_to_field_address_map[node] == 0x2)
-                // {
-                //     printf("ERROR: PARTICLE RANK HAS WEIRD ADDRESS %lu for cell %lu\n", node, particles[p].cell);
-                //     exit(1);
-                // }
-
-
-
                 if (PARTICLE_SOLVER_DEBUG && (node >= mesh->points_size))
-                    {printf("ERROR::: RANK %d Node %lu out of range\n", mpi_config->rank, node); exit(1);}
+                    {fprintf(output_file, "ERROR::: RANK %d Node %lu out of range\n", mpi_config->rank, node); exit(1);}
                 if (PARTICLE_SOLVER_DEBUG && (node_to_field_address_map[node] < (flow_aos<T> *)5))
-                    {printf("Rank %d Block %lu cell %lu node %lu flow_pointer %p block_flow_pointer %p size %lu\n", mpi_config->rank, block_id, particles[p].cell, node, node_to_field_address_map[node], all_interp_node_flow_fields[block_id], node_flow_array_sizes[block_id] ); exit(1);};
+                    {fprintf(output_file, "Rank %d Block %lu cell %lu node %lu flow_pointer %p block_flow_pointer %p size %lu\n", mpi_config->rank, block_id, particles[p].cell, node, node_to_field_address_map[node], all_interp_node_flow_fields[block_id], node_flow_array_sizes[block_id] ); exit(1);};
 
 
                 const vec<T> node_to_particle = particles[p].x1 - mesh->points[node - mesh->shmem_point_disp];
@@ -396,7 +349,7 @@ namespace minicombust::particles
 			// if (PARTICLE_SOLVER_DEBUG) check_flow_field_exit ( "SOLVE SPRAY: Interpolated particle value ", &particles[p].local_flow_value, &mesh->dummy_flow_field, p );
         }
 
-        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Finished interpolation. Starting spray computation.\n", mpi_config->rank);
+        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Finished interpolation. Starting spray computation.\n", mpi_config->rank);
 
         node_to_field_address_map.clear(); // TODO move this? 
 
@@ -444,7 +397,7 @@ namespace minicombust::particles
     {
         performance_logger.my_papi_start();
 
-        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Running fn: update_particle_positions.\n", mpi_config->rank);
+        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Running fn: update_particle_positions.\n", mpi_config->rank);
         const uint64_t particles_size  = particles.size();
 
         uint64_t elements [mesh->num_blocks];
@@ -518,13 +471,13 @@ namespace minicombust::particles
     template<class T>
     void ParticleSolver<T>::update_spray_source_terms()
     {
-        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Running fn: update_spray_source_terms.\n", mpi_config->rank);
+        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Running fn: update_spray_source_terms.\n", mpi_config->rank);
     }
 
     template<class T> 
     void ParticleSolver<T>::map_source_terms_to_grid()
     {
-        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Running fn: map_source_terms_to_grid.\n", mpi_config->rank);
+        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Running fn: map_source_terms_to_grid.\n", mpi_config->rank);
     }
 
     template<class T> 
@@ -532,7 +485,7 @@ namespace minicombust::particles
     {
         performance_logger.my_papi_start();
 
-        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("\tRank %d: Running fn: interpolate_data.\n", mpi_config->rank);
+        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "\tRank %d: Running fn: interpolate_data.\n", mpi_config->rank);
 
         performance_logger.my_papi_stop(performance_logger.interpolation_kernel_event_counts, &performance_logger.interpolation_time);
     }
@@ -545,7 +498,7 @@ namespace minicombust::particles
         static int count = 0;
         const int  comms_timestep = 1;
 
-        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("Rank %d: Start particle timestep\n", mpi_config->rank);
+        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "Rank %d: Start particle timestep\n", mpi_config->rank);
         if ( ((count + 1) % 100) == 0 )
         {
             uint64_t particles_in_simulation = particles.size();
@@ -565,12 +518,8 @@ namespace minicombust::particles
 
             if ( mpi_config->particle_flow_rank == 0 )
             {
-                // printf("Timestep %6d Particle array mem (TOTAL %8.3f GB) (AVG %8.3f GB) STL mem (TOTAL %8.3f GB) (AVG %8.3f GB) Particles (TOTAL %lu) (AVG %lu) \n", count, arr_usage_total,               arr_usage_total               / mpi_config->particle_flow_world_size, 
-                //                                                                                                                                                             stl_usage_total,               stl_usage_total               / mpi_config->particle_flow_world_size, 
-                //                                                                                                                                                             total_particles_in_simulation, total_particles_in_simulation / mpi_config->particle_flow_world_size);
-                printf("Timestep %6d Particle mem (TOTAL %8.3f GB) (AVG %8.3f GB) Particles (TOTAL %lu) (AVG %lu) \n", count + 1, (arr_usage_total + stl_usage_total + mesh_usage_total), (arr_usage_total + stl_usage_total + mesh_usage_total) / mpi_config->particle_flow_world_size, 
+                fprintf(output_file, "Timestep %6d Particle mem (TOTAL %8.3f GB) (AVG %8.3f GB) Particles (TOTAL %lu) (AVG %lu) \n", count + 1, (arr_usage_total + stl_usage_total + mesh_usage_total), (arr_usage_total + stl_usage_total + mesh_usage_total) / mpi_config->particle_flow_world_size, 
                                                                                                                               total_particles_in_simulation,                           total_particles_in_simulation                         / mpi_config->particle_flow_world_size);
-
             }
         }
 
@@ -614,7 +563,7 @@ namespace minicombust::particles
                 {
                     particle_timing[i] /= mpi_config->particle_flow_world_size;
                 }
-                printf("\nParticle Timing: \nRelease: %f\nCalc update particles: %f\nSolve Spray: %f\nUpdate: %f\n",particle_timing[0],particle_timing[1],particle_timing[2],particle_timing[3]);
+                fprintf(output_file, "\nParticle Timing: \nRelease: %f\nCalc update particles: %f\nSolve Spray: %f\nUpdate: %f\n",particle_timing[0],particle_timing[1],particle_timing[2],particle_timing[3]);
             }
             else
             {
@@ -626,6 +575,6 @@ namespace minicombust::particles
         count++;
 		nvtxRangePop();
 
-        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  printf("Rank %d: Stop particle timestep\n", mpi_config->rank);
+        if (PARTICLE_SOLVER_DEBUG && mpi_config->rank == mpi_config->particle_flow_rank )  fprintf(output_file, "Rank %d: Stop particle timestep\n", mpi_config->rank);
     }
 }   // namespace minicombust::particles 

--- a/include/visit/VisitWriter.hpp
+++ b/include/visit/VisitWriter.hpp
@@ -124,6 +124,115 @@ namespace minicombust::visit
                 }
             }
 
+            void write_flow(string filename, int id, phi_vector<T> *phi)
+			{
+				ofstream vtk_file;
+
+                vtk_file.open (filename + "_flow" + to_string(mpi_config->rank) + "_timestep" + to_string(id) + ".vtk");
+                vtk_file << "# vtk DataFile Version 3.0 " << endl;
+                vtk_file << "MiniCOMBUST " << endl;
+                vtk_file << "ASCII " << endl;
+                vtk_file << "DATASET POLYDATA " << endl;
+
+
+                // TODO: Allow different datatypes
+                // Print point data
+                vtk_file << endl << "POINTS " << mesh->local_mesh_size << " float"  << endl;
+                for(int cell = 0; cell < (int)mesh->local_mesh_size; cell++)
+                {
+                    const int data_per_line = 10;
+                    if (cell % data_per_line == 0)  vtk_file << endl;
+                    else             vtk_file << "  ";
+                    vtk_file << print_vec(mesh->cell_centers[cell + mesh->local_cells_disp - mesh->shmem_cell_disp]) << "\t";
+                }
+                vtk_file << endl << endl;
+
+                // Print particle values for points
+                vtk_file << endl << "VERTICES " << mesh->local_mesh_size << " " << mesh->local_mesh_size * 2  << endl;
+                uint64_t count = 0;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << "1 " << count++ << "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file << endl << "POINT_DATA " << mesh->local_mesh_size << endl;
+
+                vtk_file << "VECTORS flow_velocity float" << endl;
+                // vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << phi->U[cell]<< " " << phi->V[cell] << " " << phi->W[cell] << " " << "\t";
+                }
+                vtk_file << endl;
+	
+                vtk_file << "SCALARS flow_pressure float" << endl;
+                vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << phi->P[cell]<< "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file << "SCALARS flow_te float" << endl;
+                vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << phi->TE[cell]<< "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file << "SCALARS flow_ed float" << endl;
+                vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << phi->ED[cell]<< "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file << "SCALARS flow_tem float" << endl;
+                vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << std::setprecision(11) << phi->TEM[cell]<< "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file << "SCALARS flow_ful float" << endl;
+                vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << std::setprecision(11) << phi->PRO[cell]<< "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file << "SCALARS flow_pro float" << endl;
+                vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << std::setprecision(11) << phi->FUL[cell]<< "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file << "SCALARS flow_varf float" << endl;
+                vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << std::setprecision(11) << phi->VARF[cell]<< "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file << "SCALARS flow_varp float" << endl;
+                vtk_file << "LOOKUP_TABLE default" << endl;
+                for(uint64_t cell = 0; cell < mesh->local_mesh_size; cell++)
+                {
+                    vtk_file << std::setprecision(11) << phi->VARP[cell]<< "\t";
+                }
+                vtk_file << endl;
+
+                vtk_file.close();
+            }
+
             void write_flow_velocities (string filename, int id, phi_vector<T> *phi)
             {
                 ofstream vtk_file;

--- a/src/examples/mesh_examples.cpp
+++ b/src/examples/mesh_examples.cpp
@@ -117,7 +117,7 @@ inline void fill_neighbours( uint64_t c, vec<uint64_t> local_position, vec<uint6
     (*cell_neighbours)[(c - shmem_disp) * faces_per_cell + UP_FACE]    = up_index    ;
 }
 
-Mesh<double> *load_mesh(MPI_Config *mpi_config, vec<double> mesh_dim, vec<uint64_t> elements_per_dim, int flow_ranks)
+Mesh<double> *load_mesh(MPI_Config *mpi_config, vec<double> mesh_dim, vec<uint64_t> elements_per_dim, int flow_ranks, FILE* output_file)
 {
     const uint64_t cell_size  = 8; // Cube
     const uint64_t faces_per_cell = 6; // Cube
@@ -213,31 +213,31 @@ Mesh<double> *load_mesh(MPI_Config *mpi_config, vec<double> mesh_dim, vec<uint64
 
     if ( mpi_config->rank == 0 )
     {
-        printf("\nMesh dimensions\n");
-        cout << "\tReal dimensions (m)   : " << print_vec(mesh_dim)         << endl;
-        cout << "\tTotal cells           : " << num_cubes                   << endl;
-        cout << "\tTotal points          : " << num_points                  << endl;
-        cout << "\tElement dimensions    : " << print_vec(elements_per_dim) << endl;
-        cout << "\tFlow block dimensions : " << print_vec(block_dim)        << endl;
-        cout << "\tFlow blocks           : " << num_blocks                  << endl;
+        fprintf(output_file, "\nMesh dimensions\n");
+        fprintf(output_file, "\tReal dimensions (m)   : %f %f %f\n", mesh_dim.x, mesh_dim.y, mesh_dim.z);
+        fprintf(output_file, "\tTotal cells           : %lu\n", num_cubes);
+        fprintf(output_file, "\tTotal points          : %lu\n", num_points);
+        fprintf(output_file, "\tElement dimensions    : %lu %lu %lu\n", elements_per_dim.x, elements_per_dim.y, elements_per_dim.z);
+        fprintf(output_file, "\tFlow block dimensions : %lu %lu %lu\n", block_dim.x, block_dim.y, block_dim.z);
+        fprintf(output_file, "\tFlow blocks           : %lu\n", num_blocks);
 
         vec<uint64_t> average_block_size = { 0, 0, 0 };
         for (int i = 0; i < 3; i++) 
         {   
-            cout << "\tBlock displacement " << dim_chars[i] << "  : ";
+            fprintf(output_file, "\tBlock displacement %c : ", dim_chars[i]);
             for (uint64_t b = 0; b < block_dim[i] + 1; b++)
-                cout << flow_block_displacements[i][b] << " ";
+                fprintf(output_file, " %f ", flow_block_displacements[i][b]);
 
             for (uint64_t b = 0; b < block_dim[i]; b++)
                 average_block_size[i] = average_block_size[i] + flow_block_element_sizes[i][b];
 
             average_block_size[i] = average_block_size[i] / block_dim[i];
-            cout << endl;
+            fprintf(output_file, "\n");
         }
 
-        printf( "\tAvg Flow dimensons    : %lu %lu %lu (%lu cells)\n", average_block_size.x,  average_block_size.y,  average_block_size.z,
+        fprintf(output_file, "\tAvg Flow dimensons    : %lu %lu %lu (%lu cells)\n", average_block_size.x,  average_block_size.y,  average_block_size.z,
                                                                        average_block_size.x * average_block_size.y * average_block_size.z );
-        cout << "\tIdle flow ranks       : " << flow_ranks - num_blocks << endl;
+        fprintf(output_file, "\tIdle flow ranks       : %lu\n", flow_ranks - num_blocks);
     }
 
 
@@ -562,11 +562,10 @@ Mesh<double> *load_mesh(MPI_Config *mpi_config, vec<double> mesh_dim, vec<uint64
 
         free(face_indexes);
     }
-    // printf("Rank %d done\n", mpi_config->rank);
 
     MPI_Barrier(mpi_config->world);
 
-    Mesh<double> *mesh = new Mesh<double>(mpi_config, num_points, num_cubes, cell_size, faces_size, faces_per_cell, shmem_points, shmem_cells, faces, cell_faces, shmem_cell_neighbours, shmem_cells_per_point, num_blocks, shmem_cell_disps, shmem_point_disps, block_element_disp, block_dim, num_boundary_cells, boundary_cells, num_boundary_points, boundary_points, boundary_types, mesh_dim);
+    Mesh<double> *mesh = new Mesh<double>(mpi_config, num_points, num_cubes, cell_size, faces_size, faces_per_cell, shmem_points, shmem_cells, faces, cell_faces, shmem_cell_neighbours, shmem_cells_per_point, num_blocks, shmem_cell_disps, shmem_point_disps, block_element_disp, block_dim, num_boundary_cells, boundary_cells, num_boundary_points, boundary_points, boundary_types, mesh_dim, output_file);
 
     return mesh;
 }

--- a/src/minicombust_cpx.cpp
+++ b/src/minicombust_cpx.cpp
@@ -1,0 +1,485 @@
+#include <stdio.h>
+#include <ctime>
+#include <inttypes.h>
+
+#include "examples/mesh_examples.hpp"
+#include "examples/particle_examples.hpp"
+#include "geometry/Mesh.hpp"
+#include "utils/utils.hpp"
+
+#include <chrono>
+#include <ctime>    
+
+
+#include "particles/ParticleSolver.inl"
+#ifdef have_gpu
+	#include "flow/gpu/FlowSolver.inl"
+    #include <cuda.h>
+    #include "cuda_runtime.h"
+
+    #define AMGX_SAFE_CALL(rc) \
+    { \
+    AMGX_RC err;     \
+    char msg[4096];   \
+    switch(err = (rc)) {    \
+    case AMGX_RC_OK: \
+        break; \
+    default: \
+        fprintf(stderr, "AMGX ERROR: file %s line %6d\n", __FILE__, __LINE__); \
+        AMGX_get_error_string(err, msg, 4096);\
+        fprintf(stderr, "AMGX ERROR: %s\n", msg); \
+        AMGX_abort(NULL,1);\
+        break; \
+    } \
+    }
+
+    // #define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
+    // inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
+    // {
+    // if (code != cudaSuccess) 
+    // {
+    //     fprintf(stderr,"GPUassert: %s %s %d\n", cudaGetErrorString(code), file, line);
+    //     if (abort) exit(code);
+    // }
+    // }
+
+#else
+	#include "flow/FlowSolver.inl"
+#endif
+#include "cpx/cpx_utils.inl"
+
+using namespace minicombust::flow;
+using namespace minicombust::particles;
+using namespace minicombust::visit;
+
+
+int main_minicombust(int argc, char ** argv, MPI_Fint custom, int instance_number, struct unit units[], struct locators relative_positions[])
+{
+    char filename[2];
+	char default_name[31] = "COMBUST_output_instance_";
+	sprintf(filename, "%d", instance_number);
+	strcat(default_name, filename);
+	FILE *fp = fopen(default_name, "w");
+
+    //Input variables
+    int flow_ranks;
+    uint64_t particles_per_timestep;
+    uint64_t modifier;
+    int64_t output_iteration;
+    uint64_t ntimesteps = coupler_cycles * combust_conversion_factor;
+
+    read_inputs(&flow_ranks, &particles_per_timestep, &modifier, &output_iteration);
+
+    MPI_Comm custom_comm = MPI_Comm_f2c(custom);
+
+    MPI_Config mpi_config;
+
+    mpi_config.world = custom_comm;
+
+    // Create overall world
+    MPI_Comm_rank(mpi_config.world,  &mpi_config.rank);
+    MPI_Comm_size(mpi_config.world,  &mpi_config.world_size);
+
+    int world_rank;
+
+    MPI_Comm_rank(MPI_COMM_WORLD,  &world_rank);
+    
+    int particle_ranks = mpi_config.world_size - flow_ranks;
+
+    mpi_config.solver_type = (mpi_config.rank >= flow_ranks); // 1 for particle, 0 for flow
+    MPI_Comm_split(mpi_config.world, mpi_config.solver_type, mpi_config.rank, &mpi_config.particle_flow_world);
+    MPI_Comm_rank(mpi_config.particle_flow_world,  &mpi_config.particle_flow_rank);
+    MPI_Comm_size(mpi_config.particle_flow_world,  &mpi_config.particle_flow_world_size);
+    
+    // Create Flow/Particle Datatypes
+    MPI_Type_contiguous(sizeof(flow_aos<double>)/sizeof(double),     MPI_DOUBLE, &mpi_config.MPI_FLOW_STRUCTURE);
+    MPI_Type_contiguous(sizeof(vec<double>)/sizeof(double),          MPI_DOUBLE, &mpi_config.MPI_VEC_STRUCTURE);
+    MPI_Type_contiguous(sizeof(particle_aos<double>)/sizeof(double), MPI_DOUBLE, &mpi_config.MPI_PARTICLE_STRUCTURE);
+    MPI_Type_commit(&mpi_config.MPI_FLOW_STRUCTURE);
+    MPI_Type_commit(&mpi_config.MPI_PARTICLE_STRUCTURE);
+
+    MPI_Op_create(&sum_particle_aos<double>, 1, &mpi_config.MPI_PARTICLE_OPERATION);
+
+    // Run Configuration
+    const double   delta                        = 1.0e-5;
+   
+    // Mesh Configuration
+    vec<double>    box_dim                 = {0.05*modifier*2, 0.05*modifier, 0.05*modifier};
+    vec<uint64_t>  elements_per_dim        = {modifier*2,   modifier*1,  modifier*1};
+
+    if (mpi_config.rank == 0)  
+    {
+        fprintf(fp, "Starting miniCOMBUST..\n");
+        fprintf(fp, "MPI Configuration:\n\tFlow Ranks: %d\n\tParticle Ranks: %d\n", flow_ranks, particle_ranks);
+    }
+
+    // Performance
+    double mesh_time = 0., setup_time = 0., program_time = 0., output_time = 0.;
+
+    // Perform setup and benchmark cases
+    MPI_Barrier(mpi_config.world); setup_time  -= MPI_Wtime(); mesh_time  -= MPI_Wtime(); 
+    Mesh<double> *mesh                          = load_mesh(&mpi_config, box_dim, elements_per_dim, flow_ranks, fp);
+    MPI_Barrier(mpi_config.world); mesh_time   += MPI_Wtime();
+
+	if (mpi_config.rank == 0)  fprintf(fp, "Mesh built in %6.2fs!\n\n", mesh_time);
+
+    mpi_config.one_flow_rank             = (int *)     malloc(flow_ranks * sizeof(int));
+    mpi_config.every_one_flow_rank       = (int *)     malloc(flow_ranks * sizeof(int));
+    mpi_config.one_flow_world_size       = (int *)     malloc(flow_ranks * sizeof(int));
+    mpi_config.every_one_flow_world_size = (int *)     malloc(flow_ranks * sizeof(int));
+    mpi_config.one_flow_world            = (MPI_Comm *)malloc(flow_ranks * sizeof(MPI_Comm));
+    mpi_config.every_one_flow_world      = (MPI_Comm *)malloc(flow_ranks * sizeof(MPI_Comm));
+    mpi_config.alias_rank                = (int *)     malloc(flow_ranks * sizeof(int));
+
+    //coupling data
+    double *p_variables_data;
+    double *p_variables_recv;
+    if(mpi_config.rank == 0)
+    {
+        send_num_data(units, relative_positions, mesh->mesh_size, &p_variables_data, &p_variables_recv);
+    }
+
+    MPI_Barrier(mpi_config.world);
+
+    //Setup solvers
+    ParticleSolver<double> *particle_solver = nullptr;
+    FlowSolver<double>     *flow_solver     = nullptr;
+    ParticleDistribution<double> *particle_dist;
+    if (mpi_config.solver_type == PARTICLE)
+    {
+        uint64_t       local_particles_per_timestep   = particles_per_timestep / mpi_config.particle_flow_world_size;
+        int            remainder_particles            = particles_per_timestep % mpi_config.particle_flow_world_size;
+
+        const uint64_t reserve_particles_size         = 2 * (local_particles_per_timestep + 1) * ntimesteps;
+
+        particle_dist = load_injector_particle_distribution(particles_per_timestep, local_particles_per_timestep, remainder_particles, &mpi_config, box_dim, mesh);
+        //ParticleDistribution<double> *particle_dist = load_particle_distribution(particles_per_timestep, local_particles_per_timestep, remainder_particles, &mpi_config, mesh);
+        particle_solver = new ParticleSolver<double>(&mpi_config, ntimesteps, delta, particle_dist, mesh, reserve_particles_size, fp);
+        if(mpi_config.particle_flow_rank == 0)
+        {
+            MPI_Send(&mpi_config.particle_flow_world_size, 1, MPI_INT, 0, 10, mpi_config.world);
+            MPI_Send(&particle_solver->total_node_index_array_size, 1, MPI_UINT64_T, 0, 11, mpi_config.world);
+            MPI_Send(&particle_solver->total_node_flow_array_size, 1, MPI_UINT64_T, 0, 12, mpi_config.world);
+            MPI_Send(&particle_solver->total_cell_particle_index_array_size, 1, MPI_UINT64_T, 0, 13, mpi_config.world);
+            MPI_Send(&particle_solver->total_cell_particle_array_size, 1, MPI_UINT64_T, 0, 14, mpi_config.world);
+            MPI_Send(&particle_solver->total_neighbours_sets_size, 1, MPI_UINT64_T, 0, 15, mpi_config.world);
+            MPI_Send(&particle_solver->total_cell_particle_field_map_size, 1, MPI_UINT64_T, 0, 16, mpi_config.world);
+            MPI_Send(&particle_solver->total_particles_size, 1, MPI_UINT64_T, 0, 17, mpi_config.world);
+            MPI_Send(&particle_solver->total_node_to_field_address_map_size, 1, MPI_UINT64_T, 0, 18, mpi_config.world);
+            MPI_Send(&particle_solver->total_memory_usage, 1, MPI_UINT64_T, 0, 19, mpi_config.world);
+        }
+    }
+    else
+    {
+		#ifdef have_gpu
+			AMGX_SAFE_CALL(AMGX_initialize());
+		#else
+			PETSC_COMM_WORLD = mpi_config.particle_flow_world;
+			PetscInitialize(&argc, &argv, nullptr, nullptr);
+		#endif
+        flow_solver     = new FlowSolver<double>(&mpi_config, mesh, delta, fp);
+
+        if(mpi_config.particle_flow_rank == 0)
+        {
+            int part_world_size = 0;
+            // Array sizes
+            uint64_t total_node_index_array_size = 0;
+            uint64_t total_node_flow_array_size = 0;
+            uint64_t total_cell_particle_index_array_size = 0;
+            uint64_t total_cell_particle_array_size = 0;
+
+            // STL sizes
+            uint64_t total_neighbours_sets_size = 0;
+            uint64_t total_cell_particle_field_map_size = 0;
+
+            uint64_t total_particles_size = 0;
+            uint64_t total_node_to_field_address_map_size = 0;
+
+            uint64_t total_memory_usage = 0;
+
+            MPI_Recv(&part_world_size, 1, MPI_INT, mpi_config.particle_flow_world_size, 10, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_node_index_array_size, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 11, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_node_flow_array_size, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 12, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_cell_particle_index_array_size, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 13, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_cell_particle_array_size, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 14, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_neighbours_sets_size, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 15, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_cell_particle_field_map_size, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 16, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_particles_size, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 17, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_node_to_field_address_map_size, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 18, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&total_memory_usage, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 19, mpi_config.world, MPI_STATUS_IGNORE);
+
+            fprintf(fp, "Particle solver storage requirements (%d processes) : \n", part_world_size);
+            fprintf(fp, "\ttotal_node_index_array_size                           (TOTAL %8.2f MB) (AVG %8.2f MB) \n"    , (float) total_node_index_array_size           / 1000000.0, (float) total_node_index_array_size          / (1000000.0 * part_world_size));
+            fprintf(fp, "\ttotal_node_flow_array_size                            (TOTAL %8.2f MB) (AVG %8.2f MB) \n"    , (float) total_node_flow_array_size            / 1000000.0, (float) total_node_flow_array_size           / (1000000.0 * part_world_size));
+            fprintf(fp, "\ttotal_cell_particle_index_array_size                  (TOTAL %8.2f MB) (AVG %8.2f MB) \n"    , (float) total_cell_particle_index_array_size  / 1000000.0, (float) total_cell_particle_index_array_size / (1000000.0 * part_world_size));
+            fprintf(fp, "\ttotal_cell_particle_array_size                        (TOTAL %8.2f MB) (AVG %8.2f MB) \n"    , (float) total_cell_particle_array_size        / 1000000.0, (float) total_cell_particle_array_size       / (1000000.0 * part_world_size));
+            fprintf(fp, "\ttotal_neighbours_sets_size            (STL set)       (TOTAL %8.2f MB) (AVG %8.2f MB) \n"    , (float) total_neighbours_sets_size            / 1000000.0, (float) total_neighbours_sets_size           / (1000000.0 * part_world_size));
+            fprintf(fp, "\ttotal_cell_particle_field_map_size    (STL map)       (TOTAL %8.2f MB) (AVG %8.2f MB) \n"    , (float) total_cell_particle_field_map_size    / 1000000.0, (float) total_cell_particle_field_map_size   / (1000000.0 * part_world_size));
+            fprintf(fp, "\ttotal_particles_size                  (STL vector)    (TOTAL %8.2f MB) (AVG %8.2f MB) \n"    , (float) total_particles_size                  / 1000000.0, (float) total_particles_size                 / (1000000.0 * part_world_size));
+            fprintf(fp, "\ttotal_node_to_field_address_map_size  (STL map)       (TOTAL %8.2f MB) (AVG %8.2f MB) \n\n"  , (float) total_node_to_field_address_map_size  / 1000000.0, (float) total_node_to_field_address_map_size / (1000000.0 * part_world_size));
+
+            fprintf(fp, "\tParticle solver size                                  (TOTAL %12.2f MB) (AVG %.2f MB) \n\n"  , (float)total_memory_usage                      /1000000.0,  (float)total_memory_usage / (1000000.0 * part_world_size));
+        }
+    }
+
+	if (mpi_config.rank == 0)   cout << endl;
+    setup_time += MPI_Wtime(); MPI_Barrier(mpi_config.world); 
+
+    if (mpi_config.rank == 0)  fprintf(fp, "Mesh built in %6.2fs!\n\n", mesh_time);
+
+
+    // Output mesh 
+    MPI_Barrier(mpi_config.world); output_time -= MPI_Wtime(); 
+    if ( output_iteration != -1 )
+    {
+        VisitWriter<double> *vtk_writer = new VisitWriter<double>(mesh, &mpi_config);
+        vtk_writer->write_mesh("out/minicombust");
+    }
+    output_time += MPI_Wtime(); MPI_Barrier(mpi_config.world); 
+
+    //Remove the effects of setup on the timings
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Main loop
+    if (mpi_config.rank == 0)  fprintf(fp, "Starting simulation..\n");
+    MPI_Barrier(mpi_config.world);
+    program_time -= MPI_Wtime();
+
+    // auto start = std::chrono::system_clock::now();
+ 
+    // std::time_t start_time = std::chrono::system_clock::to_time_t(start);
+ 
+    // if (mpi_config.rank == 0) std::cout << "STARTING CLOCK 1410 " << std::ctime(&start_time) << std::endl;
+
+	for(uint64_t t = 0; t < ntimesteps; t++)
+    {
+        if (mpi_config.solver_type == PARTICLE)
+        {
+            if ((output_iteration != -1) and (((int64_t)((t+1) % output_iteration) == 0) or (t == 0)))
+            {
+                output_time -= MPI_Wtime();
+                particle_solver->output_data(t+1);
+                output_time += MPI_Wtime();
+            }
+
+            particle_solver->timestep();
+        }
+		else
+		{
+    		if ((output_iteration != -1) and (((int64_t)((t+1) % output_iteration) == 0) or (t == 0)))
+            {
+                output_time -= MPI_Wtime();
+				flow_solver->output_data(t+1);
+                output_time += MPI_Wtime();
+            }
+
+            flow_solver->timestep();
+
+            if(mpi_config.particle_flow_rank == 0)
+            {
+                if(((t+1) % combust_conversion_factor == 0) || ((hide_search == true) && ((t+1) % combust_conversion_factor) == (combust_conversion_factor - 1)))               {
+                    send_recv_data(units, relative_positions, mesh->mesh_size, t, ntimesteps, p_variables_data, p_variables_recv, fp);
+                }
+            }
+            MPI_Barrier(mpi_config.particle_flow_world);
+		}
+    }
+
+    program_time += MPI_Wtime();
+    MPI_Barrier(mpi_config.world);
+    // auto end = std::chrono::system_clock::now();
+
+    // std::time_t end_time = std::chrono::system_clock::to_time_t(end);
+
+    // if (mpi_config.rank == 0) std::cout << "ENDING CLOCK 1410 " << std::ctime(&end_time) << std::endl;
+
+    if (mpi_config.rank == 0) fprintf(fp, "Done!\n\n");
+
+    //Print logger stats and write performance counters
+    if (LOGGER) 
+    {
+        if (mpi_config.solver_type == PARTICLE)
+        {
+            particle_solver->print_logger_stats(ntimesteps, program_time);
+            if(mpi_config.particle_flow_rank == 0)
+            {
+                MPI_Send(&mpi_config.particle_flow_world_size, 1, MPI_INT, 0, 10, mpi_config.world);
+                MPI_Send(&particle_solver->logger.num_particles, 1, MPI_UINT64_T, 0, 11, mpi_config.world);
+                MPI_Send(&particle_dist->even_particles_per_timestep, 1, MPI_UINT64_T, 0, 12, mpi_config.world);
+                MPI_Send(&particle_solver->logger.emitted_particles, 1, MPI_UINT64_T, 0, 13, mpi_config.world);
+                MPI_Send(&particle_solver->logger.avg_particles, 1, MPI_DOUBLE, 0, 14, mpi_config.world);
+                MPI_Send(&particle_solver->logger.cell_checks, 1, MPI_UINT64_T, 0, 15, mpi_config.world);
+                MPI_Send(&particle_solver->logger.position_adjustments, 1, MPI_UINT64_T, 0, 16, mpi_config.world);
+                MPI_Send(&particle_solver->logger.lost_particles, 1, MPI_UINT64_T, 0, 17, mpi_config.world);
+                MPI_Send(&particle_solver->logger.boundary_intersections, 1, MPI_UINT64_T, 0, 18, mpi_config.world);
+                MPI_Send(&particle_solver->logger.decayed_particles, 1, MPI_UINT64_T, 0, 19, mpi_config.world);
+                MPI_Send(&particle_solver->logger.burnt_particles, 1, MPI_UINT64_T, 0, 20, mpi_config.world);
+                MPI_Send(&particle_solver->logger.breakups, 1, MPI_UINT64_T, 0, 21, mpi_config.world);
+                MPI_Send(&particle_solver->logger.breakup_age, 1, MPI_DOUBLE, 0, 22, mpi_config.world);
+                MPI_Send(&particle_solver->logger.sent_cells_per_block, 1, MPI_DOUBLE, 0, 23, mpi_config.world);
+                MPI_Send(&particle_solver->logger.sent_cells, 1, MPI_DOUBLE, 0, 24, mpi_config.world);
+                MPI_Send(&particle_solver->logger.nodes_recieved, 1, MPI_DOUBLE, 0, 25, mpi_config.world);
+                MPI_Send(&particle_solver->logger.useful_nodes_proportion, 1, MPI_DOUBLE, 0, 26, mpi_config.world);
+            }
+        }
+        else
+        {
+            flow_solver->print_logger_stats(ntimesteps, program_time);
+            if(mpi_config.particle_flow_rank == 0)
+            {
+                int part_world_size = 0;
+                Particle_Logger part_log;
+                uint64_t even_particles_per_timestep = 0;
+
+                MPI_Recv(&part_world_size, 1, MPI_INT, mpi_config.particle_flow_world_size, 10, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.num_particles, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 11, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&even_particles_per_timestep, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 12, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.emitted_particles, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 13, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.avg_particles, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 14, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.cell_checks, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 15, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.position_adjustments, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 16, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.lost_particles, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 17, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.boundary_intersections, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 18, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.decayed_particles, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 19, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.burnt_particles, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 20, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.breakups, 1, MPI_UINT64_T, mpi_config.particle_flow_world_size, 21, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.breakup_age, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 22, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.sent_cells_per_block, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 23, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.sent_cells, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 24, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.nodes_recieved, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 25, mpi_config.world, MPI_STATUS_IGNORE);
+                MPI_Recv(&part_log.useful_nodes_proportion, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 26, mpi_config.world, MPI_STATUS_IGNORE);
+
+                fprintf(fp, "Particle Solver Stats:                         \n");
+                fprintf(fp, "\tParticles:                                   %e\n", ((double)part_log.num_particles));
+                fprintf(fp, "\tParticles (per iter):                        %lu\n", even_particles_per_timestep*part_world_size);
+                fprintf(fp, "\tEmitted Particles:                           %lu\n", part_log.emitted_particles);
+                fprintf(fp, "\tAvg Particles (per iter):                    %e\n", part_log.avg_particles);
+                fprintf(fp, "\n");
+                fprintf(fp, "\tCell checks:                                 %e\n", ((double)part_log.cell_checks));
+                fprintf(fp, "\tCell checks (per iter):                      %e\n", ((double)part_log.cell_checks) / ntimesteps);
+                fprintf(fp, "\tCell checks (per particle, per iter):        %.2f\n", ((double)part_log.cell_checks) / (((double)part_log.num_particles)*ntimesteps));
+                fprintf(fp, "\n");
+                fprintf(fp, "\tEdge adjustments:                            %.2f\n", ((double)part_log.position_adjustments));
+                fprintf(fp, "\tEdge adjustments (per iter):                 %.2f\n", ((double)part_log.position_adjustments) / ntimesteps);
+                fprintf(fp, "\tEdge adjustments (per particle, per iter):   %.2f\n", ((double)part_log.position_adjustments) / (((double)part_log.num_particles)*ntimesteps));
+                fprintf(fp, "\tLost Particles:                              %.2f\n", ((double)part_log.lost_particles      ));
+                fprintf(fp, "\n");
+                fprintf(fp, "\tBoundary Intersections:                      %.2f\n", ((double)part_log.boundary_intersections));
+                fprintf(fp, "\tDecayed Particles:                           %e\n", ((double)part_log.decayed_particles));
+                fprintf(fp, "\tDecayed Particles:                           %.2f%%\n", round(10000.*(((double)part_log.decayed_particles) / ((double)part_log.num_particles)))/100.);
+                fprintf(fp, "\tBurnt Particles:                             %e\n", ((double)part_log.burnt_particles));
+                fprintf(fp, "\tBreakups:                                    %.2f\n", ((double)part_log.breakups));
+                fprintf(fp, "\tBreakup Age:                                 %.2f\n", ((double)part_log.breakup_age));
+                fprintf(fp, "\n");
+                fprintf(fp, "\tAvg Sent Cells       (avg per rank, block):  %.0f\n", round(part_log.sent_cells_per_block / ntimesteps));
+                fprintf(fp, "\tTotal Sent Cells     (avg per rank):         %.0f\n", round(part_log.sent_cells / ntimesteps));
+                fprintf(fp, "\tTotal Recieved Nodes (avg per rank):         %.0f\n", round(part_log.nodes_recieved / ntimesteps));
+                fprintf(fp, "\tUseful Nodes         (avg per rank):         %.0f\n", round(part_log.useful_nodes_proportion / ntimesteps));
+                fprintf(fp, "\tUseful Nodes (%%)     (avg per rank):         %.2f%%\n", round(10000.*((part_log.useful_nodes_proportion) / (part_log.nodes_recieved))) / 100.);
+            }
+        }
+    }
+
+    // Get program times
+    double setup_time_avg = 0., program_time_avg = 0., output_time_avg = 0.;
+    double setup_time_max = 0., program_time_max = 0., output_time_max = 0.;
+    double setup_time_min = 0., program_time_min = 0., output_time_min = 0.;
+    double comp_time_avg = 0., comp_time_max = 0., comp_time_min = 0.;
+    MPI_Reduce(&setup_time,    &setup_time_avg,   1, MPI_DOUBLE, MPI_SUM, 0, mpi_config.world);
+    MPI_Reduce(&setup_time,    &setup_time_max,   1, MPI_DOUBLE, MPI_MAX, 0, mpi_config.world);
+    MPI_Reduce(&setup_time,    &setup_time_min,   1, MPI_DOUBLE, MPI_MIN, 0, mpi_config.world);
+    MPI_Reduce(&program_time,  &program_time_avg, 1, MPI_DOUBLE, MPI_SUM, 0, mpi_config.world);
+    MPI_Reduce(&program_time,  &program_time_max, 1, MPI_DOUBLE, MPI_MAX, 0, mpi_config.world);
+    MPI_Reduce(&program_time,  &program_time_min, 1, MPI_DOUBLE, MPI_MIN, 0, mpi_config.world);
+    MPI_Reduce(&output_time,   &output_time_avg,  1, MPI_DOUBLE, MPI_SUM, 0, mpi_config.world);
+    MPI_Reduce(&output_time,   &output_time_max,  1, MPI_DOUBLE, MPI_MAX, 0, mpi_config.world);
+    MPI_Reduce(&output_time,   &output_time_min,  1, MPI_DOUBLE, MPI_MIN, 0, mpi_config.world);
+	if(mpi_config.solver_type == PARTICLE)
+	{
+		MPI_Reduce(&(particle_solver->compute_time), &comp_time_avg, 1,
+                MPI_DOUBLE, MPI_SUM, 0, mpi_config.particle_flow_world);
+        MPI_Reduce(&(particle_solver->compute_time), &comp_time_max, 1,
+                MPI_DOUBLE, MPI_MAX, 0, mpi_config.particle_flow_world);
+        MPI_Reduce(&(particle_solver->compute_time), &comp_time_min, 1,
+                MPI_DOUBLE, MPI_MIN, 0, mpi_config.particle_flow_world);
+	}
+	else
+	{
+		MPI_Reduce(&(flow_solver->compute_time), &comp_time_avg, 1, 
+				MPI_DOUBLE, MPI_SUM, 0, mpi_config.particle_flow_world);
+		MPI_Reduce(&(flow_solver->compute_time), &comp_time_max, 1,
+				MPI_DOUBLE, MPI_MAX, 0, mpi_config.particle_flow_world);
+		MPI_Reduce(&(flow_solver->compute_time), &comp_time_min, 1,
+				MPI_DOUBLE, MPI_MIN, 0, mpi_config.particle_flow_world);
+	}
+
+	int precision = 5+log10(max({setup_time_max, program_time_max, 
+								output_time_max, comp_time_max}));
+    precision = 2;
+    cout.precision(2);
+    cout.setf(ios::fixed);
+
+    if (mpi_config.rank == 0)
+    {
+        setup_time_avg    /= (double)mpi_config.world_size;
+        program_time_avg  /= (double)mpi_config.world_size;
+        output_time_avg   /= (double)mpi_config.world_size;
+
+        // cout << "Setup Time:            " << setw(precision) << setup_time_avg   << "s  (min " << setw(precision) << setup_time_min   << "s) " << "(max " << setw(precision) << setup_time_max    << "s)\n";
+        // cout << "Program Time:          " << setw(precision) << program_time_avg << "s  (min " << setw(precision) << program_time_min << "s) " << "(max " << setw(precision) << program_time_max  << "s)\n";
+        // cout << "Output Time:           " << setw(precision) << output_time_avg  << "s  (min " << setw(precision) << output_time_min  << "s) " << "(max " << setw(precision) << output_time_max   << "s)\n";
+
+        fprintf(fp, "Setup Time:            %.*fs  (min %.*fs) (max %.*fs)\n", precision, setup_time_avg, precision, setup_time_min, precision, setup_time_max);
+        fprintf(fp, "Program Time:            %.*fs  (min %.*fs) (max %.*fs)\n", precision, program_time_avg, precision, program_time_min, precision, program_time_max);
+        fprintf(fp, "Output Time:            %.*fs  (min %.*fs) (max %.*fs)\n", precision, output_time_avg, precision, output_time_min, precision, output_time_max);
+    }
+	MPI_Barrier(mpi_config.world);
+	if(mpi_config.particle_flow_rank == 0)
+	{
+		if(mpi_config.solver_type == PARTICLE)
+		{
+			comp_time_avg /= (double)mpi_config.particle_flow_world_size;
+            MPI_Send(&comp_time_avg, 1, MPI_DOUBLE, 0, 10, mpi_config.world);
+            MPI_Send(&comp_time_min, 1, MPI_DOUBLE, 0, 11, mpi_config.world);
+            MPI_Send(&comp_time_max, 1, MPI_DOUBLE, 0, 12, mpi_config.world);
+
+            // cout << "Particle Compute Time: " << setw(precision) << comp_time_avg 
+			// 		<< "s  (min " << setw(precision) << comp_time_min << "s) (max "
+			// 		<< setw(precision) << comp_time_max << "s)\n";
+		}
+		else
+		{
+            double part_comp_time_avg = 0., part_comp_time_min = 0., part_comp_time_max = 0.;
+            MPI_Recv(&part_comp_time_avg, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 10, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&part_comp_time_min, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 11, mpi_config.world, MPI_STATUS_IGNORE);
+            MPI_Recv(&part_comp_time_max, 1, MPI_DOUBLE, mpi_config.particle_flow_world_size, 12, mpi_config.world, MPI_STATUS_IGNORE);
+			comp_time_avg /= (double)mpi_config.particle_flow_world_size;
+
+            // cout << "Flow Compute Time:     " << setw(precision) << comp_time_avg
+			// 		<< "s  (min " << setw(precision) << comp_time_min << "s) (max "
+			// 		<< setw(precision) << comp_time_max << "s)\n";
+            fprintf(fp, "Flow Compute Time:     %.*fs  (min %.*fs) (max %.*fs)\n", precision, comp_time_avg, precision, comp_time_min, precision, comp_time_max);
+            fprintf(fp, "Particle Compute Time: %.*fs  (min %.*fs) (max %.*fs)\n", precision, part_comp_time_avg, precision, part_comp_time_min, precision, part_comp_time_max);
+		}
+	}
+
+    MPI_Barrier(mpi_config.world);
+	
+	if (mpi_config.solver_type != PARTICLE)
+	{
+		#ifdef have_gpu
+			flow_solver->AMGX_free();
+			AMGX_SAFE_CALL(AMGX_finalize());
+		#else
+			PetscFinalize();
+		#endif
+	}
+
+    MPI_Win_free(&mpi_config.win_cell_centers);
+    MPI_Win_free(&mpi_config.win_cells);
+    MPI_Win_free(&mpi_config.win_cell_neighbours);
+    MPI_Win_free(&mpi_config.win_points);
+    MPI_Win_free(&mpi_config.win_cells_per_point);
+
+    return 0;
+}


### PR DESCRIPTION
Local changes for GPU work will add support for CPX integration.

Changes:
- swap flow and particle ranks so flow ranks are "first"
- add a generic output file. When running normally, this defaults to stdout, allowing a file output easily.
- add a compile option for a CPX version. 
- comment clean up 
- remove cucollections. 

Todo:
- A better way to specify amgx paths.
- Compile the CPX version using preprocessor directives rather than a new file.

