### PR TITLE
CPU flow solver update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ## Compilers and Flags
 CC := mpicxx
-CFLAGS := -fopenmp -g -G -Wall -Wextra -std=c++2a -O3 -march=native -Wno-unknown-pragmas -Wno-deprecated-enum-enum-conversion
+#-G
+CFLAGS := -fopenmp -g -Wall -Wextra -std=c++2a -O3 -march=native -Wno-unknown-pragmas -Wno-deprecated-enum-enum-conversion
 
 LIB := -Lbuild/
 INC := -Iinclude/

--- a/include/geometry/Mesh.hpp
+++ b/include/geometry/Mesh.hpp
@@ -82,9 +82,6 @@ namespace minicombust::geometry
             uint64_t local_mesh_size;     // Number of polygons in the mesh that a flow rank owns.
             uint64_t local_points_size;     // Number of polygons in the mesh that a flow rank owns.
             uint64_t local_cells_disp;    // Number of polygons in the mesh that a flow rank owns.
-            
-            vec<T> mesh_dim;
-            FILE *fp;
 
             vec<T> cell_size_vector;      // Cell size
             vec<T> *points;               // Mesh points    = {{0.0, 0.0, 0.0}, {0.1, 0.0, 0.0}, ...}:
@@ -102,14 +99,15 @@ namespace minicombust::geometry
             uint64_t     *block_element_disp;
             vec<uint64_t> flow_block_dim;
 
-
             uint64_t  boundary_cells_size;
             uint64_t *boundary_cells;
             uint64_t  boundary_points_size;
             vec<T>   *boundary_points;
             uint64_t *boundary_types;
             
- 
+            vec<T> mesh_dim;
+            FILE *fp;
+
             uint64_t *particles_per_point; // Number of particles in each cell
 
             // Flow source terms

--- a/include/performance/PerformanceLogger.hpp
+++ b/include/performance/PerformanceLogger.hpp
@@ -39,6 +39,12 @@ namespace minicombust::performance
             int128_t *particle_interpolation_event_counts;
             int128_t *emit_event_counts;
             int128_t *update_flow_field_event_counts;
+            int128_t *get_flow_gradients_event_counts;
+            int128_t *FGM_lookup_event_counts;
+            int128_t *FLUX_event_counts;
+            int128_t *standard_solve_event_count;
+            int128_t *pressure_solve_event_count;
+            int128_t *pressure_setup_event_count;
 
             double position_time = 0.;
             double interpolation_time = 0.;
@@ -46,7 +52,13 @@ namespace minicombust::performance
             double spray_time = 0.;
             double emit_time = 0.;
             double update_flow_field_time = 0.;
-            double output; 
+            double get_flow_gradients_time = 0.;
+            double FGM_lookup_time = 0.;
+            double FLUX_time = 0.;
+            double standard_solve_time = 0.;
+            double pressure_solve_time = 0.;
+            double pressure_setup_time = 0.;
+            double output;
             
             vector<string> event_names;
 
@@ -94,6 +106,42 @@ namespace minicombust::performance
                 myfile << "updated_flow_field," << update_flow_field_time;
                 #ifdef PAPI
                 for (int e = 0; e < num_events; e++)    myfile << "," << update_flow_field_event_counts[e];
+                #endif
+                myfile << endl;
+
+                myfile << "get_flow_gradients," << get_flow_gradients_time;
+                #ifdef PAPI
+                for (int e = 0; e < num_events; e++)    myfile << "," << get_flow_gradients_event_counts[e];
+                #endif
+                myfile << endl;
+
+                myfile << "FGM_lookup," << FGM_lookup_time;
+                #ifdef PAPI
+                for (int e = 0; e < num_events; e++)    myfile << "," << FGM_lookup_event_counts[e];
+                #endif
+                myfile << endl;
+
+                myfile << "FLUX," << FLUX_time;
+                #ifdef PAPI
+                for (int e = 0; e < num_events; e++)    myfile << "," << FLUX_event_counts[e];
+                #endif
+                myfile << endl;
+
+                myfile << "solve_pressure_mat," << pressure_solve_time;
+                #ifdef PAPI
+                for (int e = 0; e < num_events; e++)    myfile << "," << pressure_solve_event_count[e];
+                #endif
+                myfile << endl;
+
+                myfile << "setup_pressure_mat," << pressure_setup_time;
+                #ifdef PAPI
+                for (int e = 0; e < num_events; e++)    myfile << "," << pressure_setup_event_count[e];
+                #endif
+                myfile << endl;
+
+                myfile << "solve_standard_mat," << standard_solve_time;
+                #ifdef PAPI
+                for (int e = 0; e < num_events; e++)    myfile << "," << standard_solve_event_count[e];
                 #endif
                 myfile << endl;
 
@@ -310,6 +358,41 @@ namespace minicombust::performance
                     update_flow_field_event_counts[i] = 0;
                 }
 
+                get_flow_gradients_event_counts = (int128_t*)malloc(sizeof(int128_t)*num_events);
+                for (int i = 0; i < num_events; i++) 
+                {
+                    get_flow_gradients_event_counts[i] = 0;
+                }
+
+                FGM_lookup_event_counts = (int128_t*)malloc(sizeof(int128_t)*num_events);
+                for (int i = 0; i < num_events; i++) 
+                {
+                    FGM_lookup_event_counts[i] = 0;
+                }
+
+                FLUX_event_counts = (int128_t*)malloc(sizeof(int128_t)*num_events);
+                for (int i = 0; i < num_events; i++) 
+                {
+                    FLUX_event_counts[i] = 0;
+                }
+
+                pressure_solve_event_count = (int128_t*)malloc(sizeof(int128_t)*num_events);
+                for (int i = 0; i < num_events; i++) 
+                {
+                    pressure_solve_event_count[i] = 0;
+                }
+
+                pressure_setup_event_count = (int128_t*)malloc(sizeof(int128_t)*num_events);
+                for (int i = 0; i < num_events; i++) 
+                {
+                    pressure_setup_event_count[i] = 0;
+                }
+
+                standard_solve_event_count = (int128_t*)malloc(sizeof(int128_t)*num_events);
+                for (int i = 0; i < num_events; i++) 
+                {
+                    standard_solve_event_count[i] = 0;
+                }
 
                 temp_count_store = (int128_t*)malloc(sizeof(int128_t)*num_events);
                 for (int e = 0; e < num_events; e++)

--- a/src/minicombust.cpp
+++ b/src/minicombust.cpp
@@ -59,12 +59,8 @@ int main (int argc, char ** argv)
 	//TODO:sort out vtk_output.
 	//TODO:ideal flow tanks seem to cause a segfault
 
-    //Extract mpi_rank with env var
-
-    char *buf = getenv("MINICOMBUST_RANK_ID");
-    const int rank_id = atoi(buf); 
-
-    buf = getenv("MINICOMBUST_FRANKS");
+    //Extract runtime parameters with env var
+    char *buf = getenv("MINICOMBUST_FRANKS");
     const int flow_ranks = atoi(buf); 
 
     buf = getenv("MINICOMBUST_PRANKS");
@@ -82,13 +78,19 @@ int main (int argc, char ** argv)
     buf = getenv("MINICOMBUST_CELLS");
     const uint64_t modifier = atoi(buf); 
 
-    cudaFree(0);
-    if (rank_id < flow_ranks) 
-    {
-        int cuda_dev = 0;
-        gpuErrchk( cudaSetDevice(cuda_dev));
-        printf("Process %d selecting device %d of %d\n", rank_id, cuda_dev, flow_ranks);
-    }
+    #ifdef have_gpu
+        //Extract mpi_rank with env var
+        buf = getenv("MINICOMBUST_RANK_ID");
+        const int rank_id = atoi(buf); 
+        
+        cudaFree(0);
+        if (rank_id < flow_ranks) 
+        {
+            int cuda_dev = 0;
+            gpuErrchk( cudaSetDevice(cuda_dev));
+            printf("Process %d selecting device %d of %d\n", rank_id, cuda_dev, flow_ranks);
+        }
+    #endif
 
     // MPI Initialisation 
     MPI_Init(&argc, &argv);


### PR DESCRIPTION
Bring the main CPU up to date with current changes.

main changes:
- CPU flow solver:
     - uses a direct inverse for the gradient compute.
     - repeats for 3 outer iterations 
     - PETSc matrices correctly preallocated.
     - face normals correctly computed
-Build system reflects GPU and non-GPU code correctly.
-CPU Performance counters for remaining flow solver functions.